### PR TITLE
feat(SettingFragment Notifier GarnetDatabaseHelper): 实现每周通知无日期待办 保存设置…

### DIFF
--- a/app/src/main/java/com/example/garnet/GarnetDatabaseHelper.java
+++ b/app/src/main/java/com/example/garnet/GarnetDatabaseHelper.java
@@ -191,8 +191,12 @@ public class GarnetDatabaseHelper extends SQLiteOpenHelper {
     }
 /**获得以YYYY-MM-DD格式指定字符串对应日期中，所有未完成待办构成的字符串，以'\n'分隔*/
     public String loadTodoString(final Date date) {
-        List<String> taskFoundList = new ArrayList<>(5);//预计5个差不多，一天不会有那么多待办
         String dateString = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(date);
+        return loadTodoString(dateString);
+    }
+
+    public String loadTodoString(String dateString){
+        List<String> taskFoundList = new ArrayList<>(5);//预计5个差不多，一天不会有那么多待办
         Log.d("NOTI", "Loading todo at date:" + dateString);
         try (SQLiteDatabase db = this.getWritableDatabase()){
             Cursor cursor = db.query(TABLE_TODO,

--- a/app/src/main/java/com/example/garnet/Notifier.java
+++ b/app/src/main/java/com/example/garnet/Notifier.java
@@ -2,6 +2,7 @@ package com.example.garnet;
 
 import android.app.Notification;
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -11,27 +12,62 @@ import androidx.core.app.NotificationCompat;
 
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Objects;
 
 // 用于创建通知
 public class Notifier extends BroadcastReceiver {
     public static final String CHANNEL_ID = "daily_todo_channel";
-    public static final int  NOTIFICATION_ID = 1;
+    public static final int DAILY_NOTIFICATION_ID = 1;
+    public static final int  START_ACTIVITY = 2; // TODO: 2024-08-05 这些pendingIntent的Id应该专门存储 
+    public static final int WEEKLY_NOTIFICATION_ID = 3;
+    public static final String DAILY_NOTIFICATION = "dailyNotification";
+    public static final String WEEKLY_NOTIFICATION = "weeklyNotification";
+    public static final String NOTIFICATION_TYPE = "notificationType";
 
     @Override
     public void onReceive(Context context, Intent intent) {
         Date dateToday = Calendar.getInstance().getTime();
-        String message = new GarnetDatabaseHelper(context).loadTodoString(dateToday);
-        Log.d("NOTI", "preparing to fire notification message: " + message);
         Log.d("NOTI", "dateToday is: " + dateToday.toString());
-        if ( message != null ){//如果当日有未完成待办才发送通知
-            Notification notification = new NotificationCompat.Builder(context, CHANNEL_ID)
-                    .setSmallIcon(R.drawable.ic_launcher_foreground)
-                    .setContentTitle("今日待办")
-                    .setContentText(message)
-                    .build();
-            Log.d("NOTI","Notification sent!");
-            NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-            manager.notify(NOTIFICATION_ID, notification);
+
+        //给notification添加一个pendingIntent，点击时打开应用
+        Intent startActivity = new Intent(context, MainActivity.class);
+        PendingIntent pendingIntent = PendingIntent.getActivity(
+                context,
+                Notifier.START_ACTIVITY,
+                startActivity,
+                PendingIntent.FLAG_IMMUTABLE);
+
+        String notificationType = intent.getStringExtra(NOTIFICATION_TYPE);
+
+        if (notificationType.equals(DAILY_NOTIFICATION)) {
+            String message = new GarnetDatabaseHelper(context).loadTodoString(dateToday);
+            Log.d("NOTI", "preparing to fire notification message: " + message);
+            if ( message != null ){//如果当日有未完成待办才发送通知
+                Notification notification = new NotificationCompat.Builder(context, CHANNEL_ID)
+                        .setSmallIcon(R.drawable.ic_launcher_foreground)
+                        .setContentTitle("今日待办")
+                        .setContentText(message)
+                        .setContentIntent(pendingIntent)
+                        .build();
+                Log.d("NOTI","Notification sent!");
+                NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+                manager.notify(DAILY_NOTIFICATION_ID, notification);
+            }
+        } else if (notificationType.equals(WEEKLY_NOTIFICATION)) {
+            String message = new GarnetDatabaseHelper(context).loadTodoString("无日期");
+            Log.d("NOTI", "preparing to fire notification message: " + message);
+            if ( message != null ){//如果当日有未完成待办才发送通知
+                Notification notification = new NotificationCompat.Builder(context, CHANNEL_ID)
+                        .setSmallIcon(R.drawable.ic_launcher_foreground)
+                        .setContentTitle("未完成无日期待办")
+                        .setContentText(message)
+                        .setContentIntent(pendingIntent)
+                        .build();
+                Log.d("NOTI","Notification sent!");
+                NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+                manager.notify(DAILY_NOTIFICATION_ID, notification);// TODO: 2024-08-05 这里这个id有什么用？为什么要重复用1
+
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/garnet/SettingFragment.java
+++ b/app/src/main/java/com/example/garnet/SettingFragment.java
@@ -9,6 +9,7 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 
 import androidx.appcompat.widget.SwitchCompat;
@@ -19,34 +20,50 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Toast;
+
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 
 public class SettingFragment extends Fragment {
-
+    private SwitchCompat dailyNotificationSwitchCompat;
+    private SwitchCompat weeklyNotificationSwitchCompat;
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         View rootView = inflater.inflate(R.layout.fragment_setting, container, false);
-        SwitchCompat switchCompat = rootView.findViewById(R.id.daily_notification_switch);
 
+        initDailyNotificationSwitch(rootView);
+        initConfirmButton(rootView);
+        initWeeklyNotificationSwitch(rootView);
         createNotificationChannel();
 
-        switchCompat.setOnCheckedChangeListener((buttonView, isChecked) -> {
+        return rootView;
+    }
+
+    private void initDailyNotificationSwitch(View rootView){
+        dailyNotificationSwitchCompat = rootView.findViewById(R.id.daily_notification_switch);
+        SharedPreferences sharedPreferences = getActivity().getSharedPreferences("settings", Context.MODE_PRIVATE);
+        boolean notification = sharedPreferences.getBoolean("dailyNotification", false);
+        dailyNotificationSwitchCompat.setChecked(notification);
+
+        dailyNotificationSwitchCompat.setOnCheckedChangeListener((buttonView, isChecked) -> {
             // Create an intent for the Notification BroadcastReceiver
             Intent intent = new Intent(requireActivity(), Notifier.class);
+            intent.putExtra(Notifier.NOTIFICATION_TYPE, Notifier.DAILY_NOTIFICATION);
             // Create a PendingIntent for the broadcast
             PendingIntent pendingIntent = PendingIntent.getBroadcast(
                     requireActivity(),
-                    Notifier.NOTIFICATION_ID,
+                    Notifier.DAILY_NOTIFICATION_ID,
                     intent,
                     PendingIntent.FLAG_IMMUTABLE
             );
             if (isChecked) {
                 Log.d("NOTI", "turned on notification");
                 if (checkNotificationPermissions(requireActivity())) {
-                    scheduleNotification(pendingIntent);
+                    scheduleDailyNotification(pendingIntent);
                 }
             } else {
                 Log.d("NOTI", "turned off notification");
@@ -54,7 +71,57 @@ public class SettingFragment extends Fragment {
                 alarmManager.cancel(pendingIntent);
             }
         });
-        return rootView;
+    }
+    private void initWeeklyNotificationSwitch(View rootView){
+        weeklyNotificationSwitchCompat = rootView.findViewById(R.id.weekly_notification_switch);
+        SharedPreferences sharedPreferences = getActivity().getSharedPreferences("settings", Context.MODE_PRIVATE);
+        boolean notification = sharedPreferences.getBoolean("weeklyNotification", false);
+        weeklyNotificationSwitchCompat.setChecked(notification);
+
+        weeklyNotificationSwitchCompat.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            Intent intent = new Intent(requireActivity(), Notifier.class);
+            intent.putExtra(Notifier.NOTIFICATION_TYPE, Notifier.WEEKLY_NOTIFICATION);
+            // Create a PendingIntent for the broadcast
+            PendingIntent pendingIntent = PendingIntent.getBroadcast(
+                    requireActivity(),
+                    Notifier.WEEKLY_NOTIFICATION_ID,
+                    intent,
+                    PendingIntent.FLAG_IMMUTABLE
+            );
+            if (isChecked) {
+                Log.d("NOTI", "turned on notification");
+                if (checkNotificationPermissions(requireActivity())) {
+                    scheduleWeeklyNotification(pendingIntent);
+                }
+            } else {
+                Log.d("NOTI", "turned off notification");
+                AlarmManager alarmManager = (AlarmManager) requireContext().getSystemService(Context.ALARM_SERVICE); // 可能有问题
+                alarmManager.cancel(pendingIntent);
+            }
+        });
+    }
+    private void initConfirmButton(View rootView){
+        FloatingActionButton confirmButton = rootView.findViewById(R.id.setting_confirm_fab);
+
+        confirmButton.setOnClickListener(v -> {
+            SharedPreferences preferences = getActivity().getSharedPreferences("settings",Context.MODE_PRIVATE);
+            SharedPreferences.Editor editor = preferences.edit();
+            editor.putBoolean("dailyNotification", dailyNotificationSwitchCompat.isChecked());
+            editor.putBoolean("weeklyNotification", weeklyNotificationSwitchCompat.isChecked());
+            editor.apply();
+
+//            Intent intent1 = new Intent(requireActivity(), Notifier.class);
+//            PendingIntent pendingIntent = PendingIntent.getBroadcast(
+//                    requireActivity(),
+//                    Notifier.NOTIFICATION_ID,
+//                    intent1,
+//                    PendingIntent.FLAG_IMMUTABLE
+//            );
+//            AlarmManager alarmManager = (AlarmManager) requireActivity().getSystemService(Context.ALARM_SERVICE);
+//            alarmManager.set(AlarmManager.RTC_WAKEUP, System.currentTimeMillis(), pendingIntent);
+//
+            Toast.makeText(getActivity(), "设置已保存", Toast.LENGTH_SHORT).show();
+        });
     }
 
     private void createNotificationChannel() {
@@ -87,9 +154,9 @@ public class SettingFragment extends Fragment {
         return true;
     }
 
-    private void scheduleNotification(PendingIntent pendingIntent) {
+    private void scheduleDailyNotification(PendingIntent pendingIntent) {
         AlarmManager alarmManager = (AlarmManager) requireActivity().getSystemService(Context.ALARM_SERVICE);
-        long time = getSendTimeInMillis();//以毫秒计，发送通知的时间
+        long time = getDailySendTimeInMillis();//以毫秒计，发送通知的时间
 
         Log.d("NOTI", "time: " + time);
         Log.d("NOTI", "Calendar.getInstance().getTimeInMillis(): " + Calendar.getInstance().getTimeInMillis());
@@ -103,11 +170,26 @@ public class SettingFragment extends Fragment {
         Log.d("NOTI", "done setting pending intent");
     }
 
+    private void scheduleWeeklyNotification(PendingIntent pendingIntent){
+        AlarmManager alarmManager = (AlarmManager) requireActivity().getSystemService(Context.ALARM_SERVICE);
+        long time = getWeeklySendTimeInMillis();
+        Log.d("NOTI", "time: " + time);
+        Log.d("NOTI", "Calendar.getInstance().getTimeInMillis(): " + Calendar.getInstance().getTimeInMillis());
+
+        alarmManager.setRepeating(AlarmManager.RTC_WAKEUP,
+                time,
+                AlarmManager.INTERVAL_DAY*7,
+                pendingIntent);
+        Log.d("NOTI", "alarm set at: " + new SimpleDateFormat("yyyy-MM-dd, HH:mm:ss").format(time));
+
+        Log.d("NOTI", "done setting pending intent");
+    }
+
     /**
      * 获取第一次发送通知的时间，如果今天没到8.00am就是今天8.00am，如果今天过了8.00am就是明天的8.00am
      */
     @SuppressLint("SimpleDateFormat")//用于打log，忽视这warning
-    private long getSendTimeInMillis() {
+    private long getDailySendTimeInMillis() {
         Calendar calendar = Calendar.getInstance();
         // 获得今天8:00:00am
         calendar.set(Calendar.HOUR_OF_DAY, 8);
@@ -121,6 +203,24 @@ public class SettingFragment extends Fragment {
         Log.d("NOTI", "will trigger on: " +
                 new SimpleDateFormat("yyyy-MM-dd, HH:mm:ss").format(calendar.getTime()));//打Log不需要在意warning
         //HH24小时制，hh12小时制
+        return calendar.getTimeInMillis();
+    }
+
+    private long getWeeklySendTimeInMillis(){
+        Calendar calendar = Calendar.getInstance();
+        int currentDayOfWeek = calendar.get(Calendar.DAY_OF_WEEK);
+
+        if(currentDayOfWeek == Calendar.SUNDAY){
+            Log.d("NOTI", "Sunday today");
+        }
+        else{
+            calendar.set(Calendar.DAY_OF_WEEK, 7);
+            calendar.set(Calendar.HOUR_OF_DAY, 0);
+            calendar.set(Calendar.MINUTE, 0);
+            calendar.set(Calendar.SECOND, 0);
+            Log.d("NOTI", "will trigger on: " +
+                    new SimpleDateFormat("yyyy-MM-dd, HH:mm:ss").format(calendar.getTime()));//打Log不需要在意warning
+        }
         return calendar.getTimeInMillis();
     }
 }

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -5,10 +5,39 @@
     android:layout_height="match_parent"
     tools:context=".SettingFragment">
 
-   <androidx.appcompat.widget.SwitchCompat
+
+
+   <androidx.cardview.widget.CardView
+       android:layout_width="match_parent"
+       android:layout_height="wrap_content"
+       android:id="@+id/daily_notification_card">
+      <androidx.appcompat.widget.SwitchCompat
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="每日早晨8:00通知"
+          android:id="@+id/daily_notification_switch"/>
+   </androidx.cardview.widget.CardView>
+
+   <androidx.cardview.widget.CardView
+       android:layout_width="match_parent"
+       android:layout_height="wrap_content"
+       android:layout_below="@+id/daily_notification_card"
+       android:id="@+id/weekly_notification_card">
+      <androidx.appcompat.widget.SwitchCompat
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="每周日通知未完成的无日期待办"
+          android:id="@+id/weekly_notification_switch"/>
+   </androidx.cardview.widget.CardView>
+
+
+
+   <com.google.android.material.floatingactionbutton.FloatingActionButton
        android:layout_width="wrap_content"
        android:layout_height="wrap_content"
-       android:text="每日早晨8:00通知"
-       android:id="@+id/daily_notification_switch"/>
-
+       android:layout_centerHorizontal="true"
+       android:layout_alignParentBottom="true"
+       android:layout_marginBottom="20dp"
+       android:id="@+id/setting_confirm_fab"
+       android:src="@drawable/baseline_done_24"/>
 </RelativeLayout>


### PR DESCRIPTION
… 实现通知跳转

实现了每周通知无日期待办，具体为每周日0点发送通知，在开启设置时，如果正好是周日，立即发送通知
实现了保存设置，通过sharedReference保存，点击settingFragment下方的对钩按钮，即保存设置 实现了通知跳转，点击发送的通知即可打开应用，具体为打开mainActivity